### PR TITLE
Add macOS DMG codesigning and notarization

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -391,8 +391,14 @@ jobs:
             exit 1
           fi
 
-          mapfile -t identities < <(security find-identity -v -p codesigning "$keychain_path" | \
-            sed -E 's/^[[:space:]]*[0-9]+\) ([0-9A-Fa-f]+) "(.*)"$/\1|\2/' || true)
+          identities=()
+          while IFS= read -r line; do
+            entry=$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*[0-9]+\) ([0-9A-Fa-f]+) "(.*)"$/\1|\2/')
+            if [[ "$entry" == *"|"* ]]; then
+              identities+=("$entry")
+            fi
+          done < <(security find-identity -v -p codesigning "$keychain_path" || true)
+
           if [[ ${#identities[@]} -eq 0 ]]; then
             echo "No signing identities available in $keychain_path" >&2
             exit 1

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -416,27 +416,56 @@ jobs:
           fi
 
           provided="${PROVIDED_IDENTITY:-}"
-          provided_lower="$(printf '%s' "$provided" | tr '[:upper:]' '[:lower:]')"
+          provided_lower=""
+          if [[ -n "$provided" ]]; then
+            provided_lower="$(printf '%s' "$provided" | tr '[:upper:]' '[:lower:]')"
+          fi
 
-          identities=()
+          resolved=""
+          resolved_label=""
+          first_fingerprint=""
+          first_label=""
+          found_any=0
+          matched=0
+          match_fingerprint=""
+          match_label=""
 
-          collect_identities() {
-            local target="$1"
-            local output
-            if [[ -n "$target" ]]; then
-              echo "Attempting to resolve signing identities in $target"
-              output=$(security find-identity -v -p codesigning "$target" 2>&1 || true)
-            else
-              echo "Attempting to resolve signing identities from the default keychain search list"
-              output=$(security find-identity -v -p codesigning 2>&1 || true)
-            fi
-            printf '%s\n' "$output"
+          resolve_from_output() {
+            local output="$1"
             while IFS= read -r line; do
               entry=$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*[0-9]+\) ([0-9A-Fa-f]+) "(.*)"$/\1|\2/')
-              if [[ "$entry" == *"|"* ]]; then
-                identities+=("$entry")
+              if [[ "$entry" != *"|"* ]]; then
+                continue
+              fi
+              found_any=1
+              fingerprint="${entry%%|*}"
+              label="${entry#*|}"
+              if [[ -z "$first_fingerprint" ]]; then
+                first_fingerprint="$fingerprint"
+                first_label="$label"
+              fi
+              if [[ -n "$provided_lower" ]]; then
+                fp_lower="$(printf '%s' "$fingerprint" | tr '[:upper:]' '[:lower:]')"
+                if [[ "$fp_lower" == "$provided_lower" ]]; then
+                  resolved="$fingerprint"
+                  resolved_label="$label"
+                  matched=1
+                  match_fingerprint="$fingerprint"
+                  match_label="$label"
+                  return 0
+                fi
+                label_lower="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')"
+                if [[ "$label_lower" == "$provided_lower" ]]; then
+                  resolved="$fingerprint"
+                  resolved_label="$label"
+                  matched=1
+                  match_fingerprint="$fingerprint"
+                  match_label="$label"
+                  return 0
+                fi
               fi
             done <<<"$output"
+            return 1
           }
 
           declare -a search_targets=("$keychain_path")
@@ -446,50 +475,36 @@ jobs:
           search_targets+=("")
 
           for target in "${search_targets[@]}"; do
-            collect_identities "$target"
-            if [[ ${#identities[@]} -gt 0 ]]; then
+            if [[ -n "$target" ]]; then
+              echo "Attempting to resolve signing identities in $target"
+              output=$(security find-identity -v -p codesigning "$target" 2>&1 || true)
+            else
+              echo "Attempting to resolve signing identities from the default keychain search list"
+              output=$(security find-identity -v -p codesigning 2>&1 || true)
+            fi
+            printf '%s\n' "$output"
+            resolve_from_output "$output"
+            if [[ -n "$resolved" ]]; then
               break
             fi
           done
 
-          resolved=""
-          resolved_label=""
-
-          if [[ -n "$provided" ]]; then
-            for entry in "${identities[@]}"; do
-              fingerprint="${entry%%|*}"
-              label="${entry#*|}"
-              if [[ -z "$fingerprint" ]]; then
-                continue
-              fi
-              fp_lower="$(printf '%s' "$fingerprint" | tr '[:upper:]' '[:lower:]')"
-              if [[ "$fp_lower" == "$provided_lower" ]]; then
-                resolved="$fingerprint"
-                resolved_label="$label"
-                break
-              fi
-              label_lower="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')"
-              if [[ "$label_lower" == "$provided_lower" ]]; then
-                resolved="$fingerprint"
-                resolved_label="$label"
-                break
-              fi
-            done
-
-            if [[ -z "$resolved" ]]; then
+          if [[ -n "$provided" && -z "$resolved" ]]; then
+            if [[ $found_any -eq 0 ]]; then
               echo "Provided codesign identity not discovered in signing keychain; falling back to provided value" >&2
-              resolved="$provided"
             else
-              echo "Matched provided codesign identity to fingerprint $resolved"
+              echo "Provided codesign identity not matched to imported certificates; falling back to provided value" >&2
             fi
+            resolved="$provided"
           fi
 
           if [[ -z "$resolved" ]]; then
-            if [[ ${#identities[@]} -eq 0 ]]; then
+            if [[ $found_any -eq 0 ]]; then
               echo "No signing identities available in the signing keychain or default search list" >&2
               exit 1
             fi
-            IFS='|' read -r resolved resolved_label <<<"${identities[0]}"
+            resolved="$first_fingerprint"
+            resolved_label="$first_label"
             echo "Using first available codesign identity fingerprint $resolved"
           fi
 
@@ -498,21 +513,26 @@ jobs:
             exit 1
           fi
 
-          if [[ -n "$provided" && -n "$resolved_label" ]]; then
-            provided_label_lower="$(printf '%s' "$resolved_label" | tr '[:upper:]' '[:lower:]')"
-            if [[ "$provided_label_lower" != "$provided_lower" && "$resolved" != "$provided" ]]; then
-              echo "Provided codesign identity secret differs from resolved fingerprint; codesign will use $resolved" >&2
-            fi
+          if [[ $matched -eq 1 ]]; then
+            echo "Matched provided codesign identity to fingerprint $match_fingerprint"
+          elif [[ -n "$provided" && "$resolved" != "$provided" ]]; then
+            echo "Provided codesign identity secret differs from resolved fingerprint; codesign will use $resolved" >&2
           fi
 
           if [[ -n "$resolved_label" ]]; then
             echo "Using identity label: $resolved_label"
+          elif [[ -n "$match_label" ]]; then
+            echo "Using identity label: $match_label"
+          elif [[ -n "$provided" ]]; then
+            echo "Using identity label: $provided"
           fi
 
           {
             echo "CODESIGN_IDENTITY_RESOLVED=$resolved"
             if [[ -n "$resolved_label" ]]; then
               echo "CODESIGN_IDENTITY_LABEL=$resolved_label"
+            elif [[ -n "$match_label" ]]; then
+              echo "CODESIGN_IDENTITY_LABEL=$match_label"
             elif [[ -n "$provided" ]]; then
               echo "CODESIGN_IDENTITY_LABEL=$provided"
             fi

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -415,6 +415,9 @@ jobs:
             exit 1
           fi
 
+          provided="${PROVIDED_IDENTITY:-}"
+          provided_lower="$(printf '%s' "$provided" | tr '[:upper:]' '[:lower:]')"
+
           identities=()
 
           collect_identities() {
@@ -449,23 +452,16 @@ jobs:
             fi
           done
 
-          if [[ ${#identities[@]} -eq 0 ]]; then
-            echo "No signing identities available in the signing keychain or default search list" >&2
-            exit 1
-          fi
-
-          provided="${PROVIDED_IDENTITY:-}"
-          provided_lower="$(printf '%s' "$provided" | tr '[:upper:]' '[:lower:]')"
           resolved=""
           resolved_label=""
 
-          for entry in "${identities[@]}"; do
-            fingerprint="${entry%%|*}"
-            label="${entry#*|}"
-            if [[ -z "$fingerprint" ]]; then
-              continue
-            fi
-            if [[ -n "$provided" ]]; then
+          if [[ -n "$provided" ]]; then
+            for entry in "${identities[@]}"; do
+              fingerprint="${entry%%|*}"
+              label="${entry#*|}"
+              if [[ -z "$fingerprint" ]]; then
+                continue
+              fi
               fp_lower="$(printf '%s' "$fingerprint" | tr '[:upper:]' '[:lower:]')"
               if [[ "$fp_lower" == "$provided_lower" ]]; then
                 resolved="$fingerprint"
@@ -478,11 +474,23 @@ jobs:
                 resolved_label="$label"
                 break
               fi
+            done
+
+            if [[ -z "$resolved" ]]; then
+              echo "Provided codesign identity not discovered in signing keychain; falling back to provided value" >&2
+              resolved="$provided"
+            else
+              echo "Matched provided codesign identity to fingerprint $resolved"
             fi
-          done
+          fi
 
           if [[ -z "$resolved" ]]; then
+            if [[ ${#identities[@]} -eq 0 ]]; then
+              echo "No signing identities available in the signing keychain or default search list" >&2
+              exit 1
+            fi
             IFS='|' read -r resolved resolved_label <<<"${identities[0]}"
+            echo "Using first available codesign identity fingerprint $resolved"
           fi
 
           if [[ -z "$resolved" ]]; then
@@ -490,14 +498,13 @@ jobs:
             exit 1
           fi
 
-          if [[ -n "$provided" ]]; then
-            resolved_lower="$(printf '%s' "$resolved" | tr '[:upper:]' '[:lower:]')"
-            if [[ "$resolved_lower" != "$provided_lower" ]]; then
-              echo "Provided codesign identity secret did not match any available identities; using $resolved instead" >&2
+          if [[ -n "$provided" && -n "$resolved_label" ]]; then
+            provided_label_lower="$(printf '%s' "$resolved_label" | tr '[:upper:]' '[:lower:]')"
+            if [[ "$provided_label_lower" != "$provided_lower" && "$resolved" != "$provided" ]]; then
+              echo "Provided codesign identity secret differs from resolved fingerprint; codesign will use $resolved" >&2
             fi
           fi
 
-          echo "Resolved codesign identity fingerprint $resolved"
           if [[ -n "$resolved_label" ]]; then
             echo "Using identity label: $resolved_label"
           fi
@@ -506,6 +513,8 @@ jobs:
             echo "CODESIGN_IDENTITY_RESOLVED=$resolved"
             if [[ -n "$resolved_label" ]]; then
               echo "CODESIGN_IDENTITY_LABEL=$resolved_label"
+            elif [[ -n "$provided" ]]; then
+              echo "CODESIGN_IDENTITY_LABEL=$provided"
             fi
           } >>"$GITHUB_ENV"
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -376,7 +376,31 @@ jobs:
             exit 1
           fi
           security list-keychains -d user -s "$keychain_path" login.keychain
-          security find-identity -v -p codesigning "$keychain_path" || true
+          declare -a search_targets=("$keychain_path")
+          if [[ "$keychain_path" == *.keychain-db ]]; then
+            search_targets+=("${keychain_path%.keychain-db}.keychain")
+          fi
+          search_targets+=("")
+
+          identities_found=0
+          for target in "${search_targets[@]}"; do
+            if [[ -n "$target" ]]; then
+              echo "Querying signing identities in $target"
+              output=$(security find-identity -v -p codesigning "$target" 2>&1 || true)
+            else
+              echo "Querying signing identities from the default keychain search list"
+              output=$(security find-identity -v -p codesigning 2>&1 || true)
+            fi
+            printf '%s\n' "$output"
+            if grep -Eq '^[[:space:]]*[0-9]+\)' <<<"$output"; then
+              identities_found=1
+              break
+            fi
+          done
+
+          if [[ $identities_found -eq 0 ]]; then
+            echo "No signing identities reported by security find-identity" >&2
+          fi
 
       - name: Resolve codesign identity
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
@@ -392,15 +416,41 @@ jobs:
           fi
 
           identities=()
-          while IFS= read -r line; do
-            entry=$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*[0-9]+\) ([0-9A-Fa-f]+) "(.*)"$/\1|\2/')
-            if [[ "$entry" == *"|"* ]]; then
-              identities+=("$entry")
+
+          collect_identities() {
+            local target="$1"
+            local output
+            if [[ -n "$target" ]]; then
+              echo "Attempting to resolve signing identities in $target"
+              output=$(security find-identity -v -p codesigning "$target" 2>&1 || true)
+            else
+              echo "Attempting to resolve signing identities from the default keychain search list"
+              output=$(security find-identity -v -p codesigning 2>&1 || true)
             fi
-          done < <(security find-identity -v -p codesigning "$keychain_path" || true)
+            printf '%s\n' "$output"
+            while IFS= read -r line; do
+              entry=$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*[0-9]+\) ([0-9A-Fa-f]+) "(.*)"$/\1|\2/')
+              if [[ "$entry" == *"|"* ]]; then
+                identities+=("$entry")
+              fi
+            done <<<"$output"
+          }
+
+          declare -a search_targets=("$keychain_path")
+          if [[ "$keychain_path" == *.keychain-db ]]; then
+            search_targets+=("${keychain_path%.keychain-db}.keychain")
+          fi
+          search_targets+=("")
+
+          for target in "${search_targets[@]}"; do
+            collect_identities "$target"
+            if [[ ${#identities[@]} -gt 0 ]]; then
+              break
+            fi
+          done
 
           if [[ ${#identities[@]} -eq 0 ]]; then
-            echo "No signing identities available in $keychain_path" >&2
+            echo "No signing identities available in the signing keychain or default search list" >&2
             exit 1
           fi
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -324,6 +324,7 @@ jobs:
           TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_PRIVATE_KEY_PASSWORD }}
 
       - name: Import Apple codesigning certificates
+        id: import-certs
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
         uses: apple-actions/import-codesign-certs@v5
         with:
@@ -331,6 +332,20 @@ jobs:
           p12-password:      ${{ secrets.MACOS_CERT_PASSWORD }}
           keychain-password: ${{ secrets.MACOS_CERT_PASSWORD }}
           keychain:          signing_temp
+
+      - name: Show imported signing identities
+        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
+        env:
+          KEYCHAIN_PATH: ${{ steps.import-certs.outputs.keychain-path }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -z "${KEYCHAIN_PATH:-}" ]]; then
+            echo "Keychain path from import step not available" >&2
+            exit 1
+          fi
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain
+          security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
 
       - name: Locate and rename Windows installer
         if: runner.os == 'Windows'
@@ -386,6 +401,7 @@ jobs:
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
         env:
           CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+          KEYCHAIN_PATH: ${{ steps.import-certs.outputs.keychain-path }}
         shell: bash
         run: |
           set -euo pipefail
@@ -394,7 +410,11 @@ jobs:
             echo "DMG_PATH environment variable is not set" >&2
             exit 1
           fi
-          codesign --force --timestamp --sign "$CODESIGN_IDENTITY" "$dmg_path"
+          if [[ -z "${KEYCHAIN_PATH:-}" ]]; then
+            echo "KEYCHAIN_PATH environment variable is not set" >&2
+            exit 1
+          fi
+          codesign --force --timestamp --sign "$CODESIGN_IDENTITY" --keychain "$KEYCHAIN_PATH" "$dmg_path"
           codesign --verify --verbose "$dmg_path"
 
       - name: Notarize macOS disk image

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -333,19 +333,38 @@ jobs:
           keychain-password: ${{ secrets.MACOS_CERT_PASSWORD }}
           keychain:          signing_temp
 
-      - name: Show imported signing identities
+      - name: Export signing keychain path
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
         env:
-          KEYCHAIN_PATH: ${{ steps.import-certs.outputs.keychain-path }}
+          KEYCHAIN_PATH_OUTPUT: ${{ steps.import-certs.outputs.keychain-path }}
         shell: bash
         run: |
           set -euo pipefail
-          if [[ -z "${KEYCHAIN_PATH:-}" ]]; then
-            echo "Keychain path from import step not available" >&2
+          keychain_path="${KEYCHAIN_PATH_OUTPUT:-}"
+          if [[ -z "$keychain_path" ]]; then
+            keychain_path="$HOME/Library/Keychains/signing_temp.keychain-db"
+            echo "import-certs output did not include keychain path; assuming $keychain_path" >&2
+          fi
+          if [[ ! -f "$keychain_path" ]]; then
+            echo "Expected signing keychain at $keychain_path not found" >&2
+            ls -al "$HOME/Library/Keychains" >&2 || true
             exit 1
           fi
-          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain
-          security find-identity -v -p codesigning "$KEYCHAIN_PATH" || true
+          echo "Using signing keychain at $keychain_path"
+          echo "KEYCHAIN_PATH=$keychain_path" >>"$GITHUB_ENV"
+
+      - name: Show imported signing identities
+        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          keychain_path="${KEYCHAIN_PATH:-}"
+          if [[ -z "$keychain_path" ]]; then
+            echo "Keychain path environment variable not available" >&2
+            exit 1
+          fi
+          security list-keychains -d user -s "$keychain_path" login.keychain
+          security find-identity -v -p codesigning "$keychain_path" || true
 
       - name: Locate and rename Windows installer
         if: runner.os == 'Windows'
@@ -401,7 +420,6 @@ jobs:
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
         env:
           CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
-          KEYCHAIN_PATH: ${{ steps.import-certs.outputs.keychain-path }}
         shell: bash
         run: |
           set -euo pipefail
@@ -410,11 +428,12 @@ jobs:
             echo "DMG_PATH environment variable is not set" >&2
             exit 1
           fi
-          if [[ -z "${KEYCHAIN_PATH:-}" ]]; then
+          keychain_path="${KEYCHAIN_PATH:-}"
+          if [[ -z "$keychain_path" ]]; then
             echo "KEYCHAIN_PATH environment variable is not set" >&2
             exit 1
           fi
-          codesign --force --timestamp --sign "$CODESIGN_IDENTITY" --keychain "$KEYCHAIN_PATH" "$dmg_path"
+          codesign --force --timestamp --sign "$CODESIGN_IDENTITY" --keychain "$keychain_path" "$dmg_path"
           codesign --verify --verbose "$dmg_path"
 
       - name: Notarize macOS disk image

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -323,47 +323,58 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_PRIVATE_KEY_PASSWORD }}
 
-      - name: Import Apple codesigning certificates
-        id: import-certs
-        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
-        uses: apple-actions/import-codesign-certs@v5
-        with:
-          p12-file-base64:   ${{ secrets.MACOS_CERT_P12 }}
-          p12-password:      ${{ secrets.MACOS_CERT_PASSWORD }}
-          keychain-password: ${{ secrets.MACOS_CERT_PASSWORD }}
-          keychain:          signing_temp
-
-      - name: Export signing keychain path
+      - name: Install the Apple certificate and provisioning profile
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
         env:
-          KEYCHAIN_PATH_OUTPUT: ${{ steps.import-certs.outputs.keychain-path }}
-          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          BUILD_CERTIFICATE_BASE64: ${{ secrets.MACOS_CERT_P12 }}
+          P12_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          INSTALLER_CERT_BASE64: ${{ secrets.MACOS_INSTALLER_CERT_P12 }}
+          INSTALLER_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
+          BUILD_PROVISION_PROFILE_BASE64: ${{ secrets.BUILD_PROVISION_PROFILE_BASE64 }}
+          KEYCHAIN_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
         shell: bash
         run: |
           set -euo pipefail
-          keychain_path="${KEYCHAIN_PATH_OUTPUT:-}"
-          if [[ -z "$keychain_path" ]]; then
-            keychain_path="$HOME/Library/Keychains/signing_temp.keychain-db"
-            echo "import-certs output did not include keychain path; assuming $keychain_path" >&2
-          fi
-          if [[ ! -f "$keychain_path" ]]; then
-            echo "Expected signing keychain at $keychain_path not found" >&2
-            ls -al "$HOME/Library/Keychains" >&2 || true
+
+          if [[ -z "${BUILD_CERTIFICATE_BASE64:-}" ]]; then
+            echo "MACOS_CERT_P12 secret must be provided" >&2
             exit 1
           fi
 
-          if [[ -z "${MACOS_CERT_PASSWORD:-}" ]]; then
-            echo "MACOS_CERT_PASSWORD secret must be provided to unlock signing keychain" >&2
-            exit 1
+          CERTIFICATE_PATH="$RUNNER_TEMP/build_certificate.p12"
+          INSTALLER_CERT_PATH="$RUNNER_TEMP/installer_certificate.p12"
+          PP_PATH="$RUNNER_TEMP/build_pp.mobileprovision"
+          KEYCHAIN_PATH="$RUNNER_TEMP/app-signing.keychain-db"
+
+          printf '%s' "$BUILD_CERTIFICATE_BASE64" | base64 --decode -o "$CERTIFICATE_PATH"
+
+          if [[ -n "${INSTALLER_CERT_BASE64:-}" ]]; then
+            printf '%s' "$INSTALLER_CERT_BASE64" | base64 --decode -o "$INSTALLER_CERT_PATH"
           fi
 
-          security set-keychain-settings -lut 21600 "$keychain_path"
-          security unlock-keychain -p "$MACOS_CERT_PASSWORD" "$keychain_path"
-          security set-key-partition-list -S apple-tool:,apple: -s -k "$MACOS_CERT_PASSWORD" "$keychain_path" >/dev/null
-          security list-keychains -d user -s "$keychain_path" login.keychain
+          if [[ -n "${BUILD_PROVISION_PROFILE_BASE64:-}" ]]; then
+            printf '%s' "$BUILD_PROVISION_PROFILE_BASE64" | base64 --decode -o "$PP_PATH"
+          fi
 
-          echo "Using signing keychain at $keychain_path"
-          echo "KEYCHAIN_PATH=$keychain_path" >>"$GITHUB_ENV"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN_PATH"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+
+          security import "$CERTIFICATE_PATH" -P "$P12_PASSWORD" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+
+          if [[ -s "$INSTALLER_CERT_PATH" ]]; then
+            security import "$INSTALLER_CERT_PATH" -P "${INSTALLER_CERT_PASSWORD:-$P12_PASSWORD}" -A -t cert -f pkcs12 -k "$KEYCHAIN_PATH"
+          fi
+
+          security set-key-partition-list -S apple-tool:,apple: -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN_PATH"
+          security list-keychains -d user -s "$KEYCHAIN_PATH" login.keychain
+
+          if [[ -s "$PP_PATH" ]]; then
+            mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+            cp "$PP_PATH" "$HOME/Library/MobileDevice/Provisioning Profiles"
+          fi
+
+          echo "KEYCHAIN_PATH=$KEYCHAIN_PATH" >>"$GITHUB_ENV"
 
       - name: Show imported signing identities
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
@@ -372,171 +383,10 @@ jobs:
           set -euo pipefail
           keychain_path="${KEYCHAIN_PATH:-}"
           if [[ -z "$keychain_path" ]]; then
-            echo "Keychain path environment variable not available" >&2
+            echo "KEYCHAIN_PATH environment variable not available" >&2
             exit 1
           fi
-          security list-keychains -d user -s "$keychain_path" login.keychain
-          declare -a search_targets=("$keychain_path")
-          if [[ "$keychain_path" == *.keychain-db ]]; then
-            search_targets+=("${keychain_path%.keychain-db}.keychain")
-          fi
-          search_targets+=("")
-
-          identities_found=0
-          for target in "${search_targets[@]}"; do
-            if [[ -n "$target" ]]; then
-              echo "Querying signing identities in $target"
-              output=$(security find-identity -v -p codesigning "$target" 2>&1 || true)
-            else
-              echo "Querying signing identities from the default keychain search list"
-              output=$(security find-identity -v -p codesigning 2>&1 || true)
-            fi
-            printf '%s\n' "$output"
-            if grep -Eq '^[[:space:]]*[0-9]+\)' <<<"$output"; then
-              identities_found=1
-              break
-            fi
-          done
-
-          if [[ $identities_found -eq 0 ]]; then
-            echo "No signing identities reported by security find-identity" >&2
-          fi
-
-      - name: Resolve codesign identity
-        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
-        env:
-          PROVIDED_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
-        shell: bash
-        run: |
-          set -euo pipefail
-          keychain_path="${KEYCHAIN_PATH:-}"
-          if [[ -z "$keychain_path" ]]; then
-            echo "KEYCHAIN_PATH environment variable is not set" >&2
-            exit 1
-          fi
-
-          provided="${PROVIDED_IDENTITY:-}"
-          provided_lower=""
-          if [[ -n "$provided" ]]; then
-            provided_lower="$(printf '%s' "$provided" | tr '[:upper:]' '[:lower:]')"
-          fi
-
-          resolved=""
-          resolved_label=""
-          first_fingerprint=""
-          first_label=""
-          found_any=0
-          matched=0
-          match_fingerprint=""
-          match_label=""
-
-          resolve_from_output() {
-            local output="$1"
-            while IFS= read -r line; do
-              entry=$(printf '%s\n' "$line" | sed -E 's/^[[:space:]]*[0-9]+\) ([0-9A-Fa-f]+) "(.*)"$/\1|\2/')
-              if [[ "$entry" != *"|"* ]]; then
-                continue
-              fi
-              found_any=1
-              fingerprint="${entry%%|*}"
-              label="${entry#*|}"
-              if [[ -z "$first_fingerprint" ]]; then
-                first_fingerprint="$fingerprint"
-                first_label="$label"
-              fi
-              if [[ -n "$provided_lower" ]]; then
-                fp_lower="$(printf '%s' "$fingerprint" | tr '[:upper:]' '[:lower:]')"
-                if [[ "$fp_lower" == "$provided_lower" ]]; then
-                  resolved="$fingerprint"
-                  resolved_label="$label"
-                  matched=1
-                  match_fingerprint="$fingerprint"
-                  match_label="$label"
-                  return 0
-                fi
-                label_lower="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')"
-                if [[ "$label_lower" == "$provided_lower" ]]; then
-                  resolved="$fingerprint"
-                  resolved_label="$label"
-                  matched=1
-                  match_fingerprint="$fingerprint"
-                  match_label="$label"
-                  return 0
-                fi
-              fi
-            done <<<"$output"
-            return 1
-          }
-
-          declare -a search_targets=("$keychain_path")
-          if [[ "$keychain_path" == *.keychain-db ]]; then
-            search_targets+=("${keychain_path%.keychain-db}.keychain")
-          fi
-          search_targets+=("")
-
-          for target in "${search_targets[@]}"; do
-            if [[ -n "$target" ]]; then
-              echo "Attempting to resolve signing identities in $target"
-              output=$(security find-identity -v -p codesigning "$target" 2>&1 || true)
-            else
-              echo "Attempting to resolve signing identities from the default keychain search list"
-              output=$(security find-identity -v -p codesigning 2>&1 || true)
-            fi
-            printf '%s\n' "$output"
-            resolve_from_output "$output"
-            if [[ -n "$resolved" ]]; then
-              break
-            fi
-          done
-
-          if [[ -n "$provided" && -z "$resolved" ]]; then
-            if [[ $found_any -eq 0 ]]; then
-              echo "Provided codesign identity not discovered in signing keychain; falling back to provided value" >&2
-            else
-              echo "Provided codesign identity not matched to imported certificates; falling back to provided value" >&2
-            fi
-            resolved="$provided"
-          fi
-
-          if [[ -z "$resolved" ]]; then
-            if [[ $found_any -eq 0 ]]; then
-              echo "No signing identities available in the signing keychain or default search list" >&2
-              exit 1
-            fi
-            resolved="$first_fingerprint"
-            resolved_label="$first_label"
-            echo "Using first available codesign identity fingerprint $resolved"
-          fi
-
-          if [[ -z "$resolved" ]]; then
-            echo "Failed to resolve a codesign identity" >&2
-            exit 1
-          fi
-
-          if [[ $matched -eq 1 ]]; then
-            echo "Matched provided codesign identity to fingerprint $match_fingerprint"
-          elif [[ -n "$provided" && "$resolved" != "$provided" ]]; then
-            echo "Provided codesign identity secret differs from resolved fingerprint; codesign will use $resolved" >&2
-          fi
-
-          if [[ -n "$resolved_label" ]]; then
-            echo "Using identity label: $resolved_label"
-          elif [[ -n "$match_label" ]]; then
-            echo "Using identity label: $match_label"
-          elif [[ -n "$provided" ]]; then
-            echo "Using identity label: $provided"
-          fi
-
-          {
-            echo "CODESIGN_IDENTITY_RESOLVED=$resolved"
-            if [[ -n "$resolved_label" ]]; then
-              echo "CODESIGN_IDENTITY_LABEL=$resolved_label"
-            elif [[ -n "$match_label" ]]; then
-              echo "CODESIGN_IDENTITY_LABEL=$match_label"
-            elif [[ -n "$provided" ]]; then
-              echo "CODESIGN_IDENTITY_LABEL=$provided"
-            fi
-          } >>"$GITHUB_ENV"
+          security find-identity -v -p codesigning "$keychain_path" || true
 
       - name: Locate and rename Windows installer
         if: runner.os == 'Windows'
@@ -590,6 +440,8 @@ jobs:
 
       - name: Codesign macOS disk image
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
+        env:
+          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -603,15 +455,12 @@ jobs:
             echo "KEYCHAIN_PATH environment variable is not set" >&2
             exit 1
           fi
-          identity="${CODESIGN_IDENTITY_RESOLVED:-}"
+          identity="${CODESIGN_IDENTITY:-}"
           if [[ -z "$identity" ]]; then
-            echo "CODESIGN_IDENTITY_RESOLVED environment variable is not set" >&2
+            echo "CODESIGN_IDENTITY secret must be provided" >&2
             exit 1
           fi
           echo "Signing $dmg_path with identity $identity"
-          if [[ -n "${CODESIGN_IDENTITY_LABEL:-}" ]]; then
-            echo "Identity label: ${CODESIGN_IDENTITY_LABEL}"
-          fi
           codesign --force --timestamp --sign "$identity" --keychain "$keychain_path" "$dmg_path"
           codesign --verify --verbose "$dmg_path"
 

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -337,6 +337,7 @@ jobs:
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
         env:
           KEYCHAIN_PATH_OUTPUT: ${{ steps.import-certs.outputs.keychain-path }}
+          MACOS_CERT_PASSWORD: ${{ secrets.MACOS_CERT_PASSWORD }}
         shell: bash
         run: |
           set -euo pipefail
@@ -350,6 +351,17 @@ jobs:
             ls -al "$HOME/Library/Keychains" >&2 || true
             exit 1
           fi
+
+          if [[ -z "${MACOS_CERT_PASSWORD:-}" ]]; then
+            echo "MACOS_CERT_PASSWORD secret must be provided to unlock signing keychain" >&2
+            exit 1
+          fi
+
+          security set-keychain-settings -lut 21600 "$keychain_path"
+          security unlock-keychain -p "$MACOS_CERT_PASSWORD" "$keychain_path"
+          security set-key-partition-list -S apple-tool:,apple: -s -k "$MACOS_CERT_PASSWORD" "$keychain_path" >/dev/null
+          security list-keychains -d user -s "$keychain_path" login.keychain
+
           echo "Using signing keychain at $keychain_path"
           echo "KEYCHAIN_PATH=$keychain_path" >>"$GITHUB_ENV"
 
@@ -365,6 +377,81 @@ jobs:
           fi
           security list-keychains -d user -s "$keychain_path" login.keychain
           security find-identity -v -p codesigning "$keychain_path" || true
+
+      - name: Resolve codesign identity
+        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
+        env:
+          PROVIDED_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          keychain_path="${KEYCHAIN_PATH:-}"
+          if [[ -z "$keychain_path" ]]; then
+            echo "KEYCHAIN_PATH environment variable is not set" >&2
+            exit 1
+          fi
+
+          mapfile -t identities < <(security find-identity -v -p codesigning "$keychain_path" | \
+            sed -E 's/^[[:space:]]*[0-9]+\) ([0-9A-Fa-f]+) "(.*)"$/\1|\2/' || true)
+          if [[ ${#identities[@]} -eq 0 ]]; then
+            echo "No signing identities available in $keychain_path" >&2
+            exit 1
+          fi
+
+          provided="${PROVIDED_IDENTITY:-}"
+          provided_lower="$(printf '%s' "$provided" | tr '[:upper:]' '[:lower:]')"
+          resolved=""
+          resolved_label=""
+
+          for entry in "${identities[@]}"; do
+            fingerprint="${entry%%|*}"
+            label="${entry#*|}"
+            if [[ -z "$fingerprint" ]]; then
+              continue
+            fi
+            if [[ -n "$provided" ]]; then
+              fp_lower="$(printf '%s' "$fingerprint" | tr '[:upper:]' '[:lower:]')"
+              if [[ "$fp_lower" == "$provided_lower" ]]; then
+                resolved="$fingerprint"
+                resolved_label="$label"
+                break
+              fi
+              label_lower="$(printf '%s' "$label" | tr '[:upper:]' '[:lower:]')"
+              if [[ "$label_lower" == "$provided_lower" ]]; then
+                resolved="$fingerprint"
+                resolved_label="$label"
+                break
+              fi
+            fi
+          done
+
+          if [[ -z "$resolved" ]]; then
+            IFS='|' read -r resolved resolved_label <<<"${identities[0]}"
+          fi
+
+          if [[ -z "$resolved" ]]; then
+            echo "Failed to resolve a codesign identity" >&2
+            exit 1
+          fi
+
+          if [[ -n "$provided" ]]; then
+            resolved_lower="$(printf '%s' "$resolved" | tr '[:upper:]' '[:lower:]')"
+            if [[ "$resolved_lower" != "$provided_lower" ]]; then
+              echo "Provided codesign identity secret did not match any available identities; using $resolved instead" >&2
+            fi
+          fi
+
+          echo "Resolved codesign identity fingerprint $resolved"
+          if [[ -n "$resolved_label" ]]; then
+            echo "Using identity label: $resolved_label"
+          fi
+
+          {
+            echo "CODESIGN_IDENTITY_RESOLVED=$resolved"
+            if [[ -n "$resolved_label" ]]; then
+              echo "CODESIGN_IDENTITY_LABEL=$resolved_label"
+            fi
+          } >>"$GITHUB_ENV"
 
       - name: Locate and rename Windows installer
         if: runner.os == 'Windows'
@@ -418,8 +505,6 @@ jobs:
 
       - name: Codesign macOS disk image
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
-        env:
-          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
         shell: bash
         run: |
           set -euo pipefail
@@ -433,7 +518,16 @@ jobs:
             echo "KEYCHAIN_PATH environment variable is not set" >&2
             exit 1
           fi
-          codesign --force --timestamp --sign "$CODESIGN_IDENTITY" --keychain "$keychain_path" "$dmg_path"
+          identity="${CODESIGN_IDENTITY_RESOLVED:-}"
+          if [[ -z "$identity" ]]; then
+            echo "CODESIGN_IDENTITY_RESOLVED environment variable is not set" >&2
+            exit 1
+          fi
+          echo "Signing $dmg_path with identity $identity"
+          if [[ -n "${CODESIGN_IDENTITY_LABEL:-}" ]]; then
+            echo "Identity label: ${CODESIGN_IDENTITY_LABEL}"
+          fi
+          codesign --force --timestamp --sign "$identity" --keychain "$keychain_path" "$dmg_path"
           codesign --verify --verbose "$dmg_path"
 
       - name: Notarize macOS disk image

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -316,13 +316,6 @@ jobs:
           $exePath = if ($command -is [System.Management.Automation.CommandInfo]) { $command.Source } else { $command.FullName }
           & $exePath /VERSION
 
-      - name: Build Tauri application
-        working-directory: dbbs-faculty-match
-        run: npm exec -- tauri build --ci
-        env:
-          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
-          TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_PRIVATE_KEY_PASSWORD }}
-
       - name: Install the Apple certificate and provisioning profile
         if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
         env:
@@ -387,6 +380,13 @@ jobs:
             exit 1
           fi
           security find-identity -v -p codesigning "$keychain_path" || true
+
+      - name: Build Tauri application
+        working-directory: dbbs-faculty-match
+        run: npm exec -- tauri build --ci
+        env:
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_PRIVATE_KEY_PASSWORD }}
 
       - name: Locate and rename Windows installer
         if: runner.os == 'Windows'

--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -210,6 +210,8 @@ jobs:
           - os: macos-13
             artifact-suffix: macos_x64
     runs-on: ${{ matrix.os }}
+    env:
+      MACOS_CERT_P12: ${{ secrets.MACOS_CERT_P12 }}
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -321,6 +323,15 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_PRIVATE_KEY_PASSWORD }}
 
+      - name: Import Apple codesigning certificates
+        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
+        uses: apple-actions/import-codesign-certs@v5
+        with:
+          p12-file-base64:   ${{ secrets.MACOS_CERT_P12 }}
+          p12-password:      ${{ secrets.MACOS_CERT_PASSWORD }}
+          keychain-password: ${{ secrets.MACOS_CERT_PASSWORD }}
+          keychain:          signing_temp
+
       - name: Locate and rename Windows installer
         if: runner.os == 'Windows'
         shell: pwsh
@@ -367,7 +378,68 @@ jobs:
             exit 1
           fi
           new_name="${{ steps.metadata.outputs.slug }}_${{ steps.metadata.outputs.version }}_${{ matrix.artifact-suffix }}.dmg"
-          mv "$dmg" "$(dirname "$dmg")/$new_name"
+          final_path="$(dirname "$dmg")/$new_name"
+          mv "$dmg" "$final_path"
+          echo "DMG_PATH=$final_path" >>"$GITHUB_ENV"
+
+      - name: Codesign macOS disk image
+        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
+        env:
+          CODESIGN_IDENTITY: ${{ secrets.CODESIGN_IDENTITY }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          dmg_path="${DMG_PATH:-}"
+          if [[ -z "$dmg_path" ]]; then
+            echo "DMG_PATH environment variable is not set" >&2
+            exit 1
+          fi
+          codesign --force --timestamp --sign "$CODESIGN_IDENTITY" "$dmg_path"
+          codesign --verify --verbose "$dmg_path"
+
+      - name: Notarize macOS disk image
+        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
+        timeout-minutes: 120
+        env:
+          NOTARIZE_APPLE_ID:  ${{ secrets.NOTARIZE_APPLE_ID }}
+          NOTARIZE_PASSWORD:  ${{ secrets.NOTARIZE_PASSWORD }}
+          NOTARIZE_TEAM_ID:   ${{ secrets.NOTARIZE_TEAM_ID }}
+        shell: bash
+        run: |
+          set -euo pipefail
+          dmg_path="${DMG_PATH:-}"
+          if [[ -z "$dmg_path" ]]; then
+            echo "DMG_PATH environment variable is not set" >&2
+            exit 1
+          fi
+          xcrun notarytool store-credentials notary-profile \
+            --apple-id "$NOTARIZE_APPLE_ID" \
+            --team-id "$NOTARIZE_TEAM_ID" \
+            --password "$NOTARIZE_PASSWORD"
+          result=$(xcrun notarytool submit "$dmg_path" \
+            --keychain-profile notary-profile \
+            --wait --output-format json)
+          status=$(echo "$result" | jq -r '.status')
+          submission_id=$(echo "$result" | jq -r '.id')
+          if [[ "$status" != "Accepted" ]]; then
+            echo "Notarization failed: $status" >&2
+            if [[ -n "$submission_id" && "$submission_id" != "null" ]]; then
+              xcrun notarytool log "$submission_id" --keychain-profile notary-profile || true
+            fi
+            exit 1
+          fi
+
+      - name: Staple notarization ticket to DMG
+        if: runner.os == 'macOS' && env.MACOS_CERT_P12 != ''
+        shell: bash
+        run: |
+          set -euo pipefail
+          dmg_path="${DMG_PATH:-}"
+          if [[ -z "$dmg_path" ]]; then
+            echo "DMG_PATH environment variable is not set" >&2
+            exit 1
+          fi
+          xcrun stapler staple "$dmg_path"
 
       - name: Upload release artifacts
         shell: bash


### PR DESCRIPTION
## Summary
- import the Apple Developer certificates during macOS release builds when signing secrets are available
- codesign, notarize, and staple the renamed DMG using the existing GitHub secret names before uploading

## Testing
- Not run (workflow change)


------
https://chatgpt.com/codex/tasks/task_e_68e446d4b8b08325ac3bc9a4fd20a53a