### PR TITLE
Document macOS notarization workflow and sign DMG bundles

### DIFF
--- a/dbbs-faculty-match/scripts/create-dmg.mjs
+++ b/dbbs-faculty-match/scripts/create-dmg.mjs
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, symlink, access, mkdir, unlink, cp, readFile } from 'node:fs/promises';
+import { mkdtemp, rm, symlink, access, mkdir, unlink, cp, readFile, readdir } from 'node:fs/promises';
 import os from 'node:os';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -37,6 +37,65 @@ function resolveArch() {
   }
 }
 
+async function codesignAppBundle(appBundlePath) {
+  const identity =
+    process.env.APPLE_CODESIGN_IDENTITY ?? process.env.CODESIGN_IDENTITY;
+
+  if (!identity) {
+    console.warn(
+      'Skipping codesign because APPLE_CODESIGN_IDENTITY was not provided.'
+    );
+    return;
+  }
+
+  const entitlements = process.env.APPLE_CODESIGN_ENTITLEMENTS;
+  const macosDir = path.join(appBundlePath, 'Contents', 'MacOS');
+  const binaries = await readdir(macosDir, { withFileTypes: true });
+
+  console.log('Codesigning macOS executables with hardened runtime...');
+
+  for (const entry of binaries) {
+    if (!entry.isFile()) {
+      continue;
+    }
+
+    const target = path.join(macosDir, entry.name);
+    await exec('codesign', [
+      '--force',
+      '--options',
+      'runtime',
+      '--timestamp',
+      '--sign',
+      identity,
+      target,
+    ]);
+  }
+
+  const appArgs = [
+    '--force',
+    '--options',
+    'runtime',
+    '--timestamp',
+    '--sign',
+    identity,
+  ];
+
+  if (entitlements) {
+    appArgs.push('--entitlements', entitlements);
+  }
+
+  appArgs.push(appBundlePath);
+
+  await exec('codesign', appArgs);
+  await exec('codesign', [
+    '--verify',
+    '--deep',
+    '--strict',
+    '--verbose=2',
+    appBundlePath,
+  ]);
+}
+
 export async function buildDmg({ debug }) {
   if (process.platform !== 'darwin') {
     return;
@@ -64,6 +123,8 @@ export async function buildDmg({ debug }) {
     console.warn(`Skipping DMG creation because app bundle was not found at ${appBundlePath}`);
     return;
   }
+
+  await codesignAppBundle(appBundlePath);
 
   const dmgDir = path.join(bundleDir, 'dmg');
   await mkdir(dmgDir, { recursive: true });


### PR DESCRIPTION
## Summary
- add an optional codesign pass to the macOS DMG helper so all binaries gain hardened runtime and timestamps before packaging
- document the macOS signing, notarization, and stapling workflow in the README for future releases

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5378fe15883259e20ae14d82f02e4