### PR TITLE
Prevent default DMG bundler from running on macOS builds

### DIFF
--- a/dbbs-faculty-match/src-tauri/tauri.conf.json
+++ b/dbbs-faculty-match/src-tauri/tauri.conf.json
@@ -25,7 +25,10 @@
   },
   "bundle": {
     "active": true,
-    "targets": "all",
+    "targets": [
+      "app",
+      "nsis"
+    ],
     "resources": [
       "resources/*",
       "resources/**/*"


### PR DESCRIPTION
## Summary
- restrict the Tauri bundler targets to the app bundle and NSIS installer so the default DMG builder is skipped
- rely on the existing post-build script to recreate the DMG without create-dmg so macOS 15 CI can unmount cleanly

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e556efcc8c8325b22c9f52754c653f